### PR TITLE
Display usernames on home page

### DIFF
--- a/app/api/users/route.ts
+++ b/app/api/users/route.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/mongodb';
+import User from '@/models/User';
+
+export async function GET() {
+  await dbConnect();
+  const users = await User.find({}, 'username');
+  const usernames = users.map((u) => u.username);
+  return NextResponse.json({ users: usernames });
+}

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,15 +1,23 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import { useAuth } from "../context/AuthContext";
 import { useRouter } from "next/navigation";
 
 export default function HomePage() {
   const { user } = useAuth();
   const router = useRouter();
+  const [users, setUsers] = useState<string[]>([]);
 
   useEffect(() => {
-    if (!user) router.push("/signin");
+    if (!user) {
+      router.push("/signin");
+    } else {
+      fetch("/api/users")
+        .then((res) => res.json())
+        .then((data) => setUsers(data.users ?? []))
+        .catch(() => setUsers([]));
+    }
   }, [user]);
 
   if (!user) return <div className="text-center mt-5">Loading...</div>;
@@ -19,6 +27,15 @@ export default function HomePage() {
       <div className="card text-center p-4 shadow-sm" style={{ maxWidth: "400px", width: "100%" }}>
         <h2 className="card-title mb-3">Welcome, {user.username} 👋</h2>
         <p className="card-text">You are now logged in to the system.</p>
+        {users.length > 0 && (
+          <ul className="list-group mb-3">
+            {users.map((name) => (
+              <li key={name} className="list-group-item">
+                {name}
+              </li>
+            ))}
+          </ul>
+        )}
         <a href="/logout" className="btn btn-danger mt-3">
           Log Out
         </a>


### PR DESCRIPTION
## Summary
- fetch list of usernames from new `/api/users` endpoint
- show all usernames on the home page
- add API route to return usernames from MongoDB

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6853b7ce0e2883268f17e09d77230494