### PR TITLE
Improve sign-in page styling

### DIFF
--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -21,46 +21,48 @@ export default function SigninPage() {
   };
 
   return (
-    <div className="flex items-center justify-center min-h-screen bg-gray-100">
-      <div className="w-full max-w-md bg-white p-6 rounded-lg shadow">
-        <h2 className="text-2xl font-semibold text-center mb-6">Sign In</h2>
+    <div className="flex items-center justify-center min-h-screen bg-gradient-to-br from-indigo-50 via-purple-50 to-pink-50">
+      <div className="w-full max-w-md bg-white p-8 rounded-xl shadow-lg">
+        <h2 className="text-3xl font-bold text-center mb-6 text-gray-800">Sign In</h2>
 
         {error && (
-          <p className="mb-4 text-center text-sm text-red-500">{error}</p>
+          <p className="mb-4 text-center text-sm text-red-600">{error}</p>
         )}
 
-        <div className="mb-4">
-          <label className="block mb-1 font-medium">Username</label>
-          <input
-            type="text"
-            className="w-full border border-gray-300 rounded px-3 py-2"
-            value={username}
-            onChange={(e) => setUsername(e.target.value)}
-            placeholder="Enter username"
-          />
+        <div className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Username</label>
+            <input
+              type="text"
+              className="w-full border border-gray-300 rounded-md px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="Enter username"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
+            <input
+              type="password"
+              className="w-full border border-gray-300 rounded-md px-4 py-2 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              placeholder="Enter password"
+            />
+          </div>
+
+          <button
+            className="w-full bg-indigo-600 text-white py-2 rounded-md hover:bg-indigo-700 transition-colors"
+            onClick={handleSignin}
+          >
+            Log In
+          </button>
         </div>
 
-        <div className="mb-4">
-          <label className="block mb-1 font-medium">Password</label>
-          <input
-            type="password"
-            className="w-full border border-gray-300 rounded px-3 py-2"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="Enter password"
-          />
-        </div>
-
-        <button
-          className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700 transition-colors"
-          onClick={handleSignin}
-        >
-          Log In
-        </button>
-
-        <p className="text-sm text-center mt-4">
+        <p className="text-sm text-center mt-6">
           No account?{' '}
-          <a href="/signup" className="text-blue-600 hover:underline">
+          <a href="/signup" className="text-indigo-600 hover:underline">
             Sign up
           </a>
         </p>


### PR DESCRIPTION
## Summary
- enhance sign-in page layout with Tailwind CSS

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6853c544ba948326afa12dd58235ac4c