### PR TITLE
Preserve session on refresh

### DIFF
--- a/app/context/AuthContext.tsx
+++ b/app/context/AuthContext.tsx
@@ -12,6 +12,8 @@ interface User {
 interface AuthContextValue {
   // Currently logged in user or null if not authenticated
   user: User | null;
+  // Indicates whether the provider is restoring a persisted session
+  loading: boolean;
   // Creates a new account; resolves to true on success
   signup: (username: string, password: string) => Promise<boolean>;
   // Logs an existing user in; resolves to true on success
@@ -26,6 +28,8 @@ const AuthContext = createContext<AuthContextValue | null>(null);
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   // Track the currently logged in user in state
   const [user, setUser] = useState<User | null>(null);
+  // Indicates whether the provider has finished restoring a session
+  const [loading, setLoading] = useState(true);
 
   // On first render, restore user from local storage to persist sessions
   useEffect(() => {
@@ -33,6 +37,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     if (storedUser) {
       setUser(JSON.parse(storedUser));
     }
+    // Loading complete after attempting to read from storage
+    setLoading(false);
   }, []);
 
   const signup = async (username: string, password: string) => {
@@ -70,7 +76,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
 
   // Provide authentication utilities and state to child components
   return (
-    <AuthContext.Provider value={{ user, signup, signin, logout }}>
+    <AuthContext.Provider value={{ user, loading, signup, signin, logout }}>
       {children}
     </AuthContext.Provider>
   );

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -5,11 +5,12 @@ import { useAuth } from "../context/AuthContext";
 import { useRouter } from "next/navigation";
 
 export default function HomePage() {
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
   const router = useRouter();
   const [users, setUsers] = useState<string[]>([]);
 
   useEffect(() => {
+    if (loading) return;
     if (!user) {
       router.push("/signin");
     } else {
@@ -18,9 +19,9 @@ export default function HomePage() {
         .then((data) => setUsers(data.users ?? []))
         .catch(() => setUsers([]));
     }
-  }, [user]);
+  }, [user, loading]);
 
-  if (!user) return <div className="text-center mt-5">Loading...</div>;
+  if (loading || !user) return <div className="text-center mt-5">Loading...</div>;
 
   return (
     <div className="container d-flex align-items-center justify-content-center min-vh-100 bg-light">


### PR DESCRIPTION
## Summary
- load session from localStorage and expose `loading` state
- wait for auth restoration before redirecting on the home page

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6854b6165db88326b4d11d721a65e3a4