### PR TITLE
Add profile details to signup

### DIFF
--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -7,15 +7,15 @@ import User from '@/models/User';
 
 // Handle POST /api/auth/signup to create a new user account
 export async function POST(req: Request) {
-  // Get the desired username and password from the request body
-  const { username, password } = await req.json();
+  // Get all provided fields from the request body
+  const { username, password, position, age, image } = await req.json();
 
   // Connect to the database before creating the user
   await dbConnect();
 
   try {
-    // Insert the new user document
-    await User.create({ username, password });
+    // Insert the new user document with additional details
+    await User.create({ username, password, position, age, image });
     return NextResponse.json({ success: true });
   } catch {
     // Likely a duplicate username or validation error

--- a/app/context/AuthContext.tsx
+++ b/app/context/AuthContext.tsx
@@ -15,7 +15,13 @@ interface AuthContextValue {
   // Indicates whether the provider is restoring a persisted session
   loading: boolean;
   // Creates a new account; resolves to true on success
-  signup: (username: string, password: string) => Promise<boolean>;
+  signup: (
+    username: string,
+    password: string,
+    position: string,
+    age: number,
+    image: string | null
+  ) => Promise<boolean>;
   // Logs an existing user in; resolves to true on success
   signin: (username: string, password: string) => Promise<boolean>;
   // Clears user information from state and storage
@@ -41,12 +47,18 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setLoading(false);
   }, []);
 
-  const signup = async (username: string, password: string) => {
-    // Call the API route to create a new user
+  const signup = async (
+    username: string,
+    password: string,
+    position: string,
+    age: number,
+    image: string | null
+  ) => {
+    // Call the API route to create a new user with extra information
     const res = await fetch("/api/auth/signup", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ username, password }),
+      body: JSON.stringify({ username, password, position, age, image }),
     });
     return res.ok;
   };

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -14,16 +14,41 @@ export default function SignupPage() {
   const { signup } = useAuth();
   const router = useRouter();
 
+  const fileToDataUrl = (file: File): Promise<string> => {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onloadend = () => {
+        if (typeof reader.result === "string") resolve(reader.result);
+        else reject(new Error("Failed to read file"));
+      };
+      reader.onerror = () => reject(new Error("Failed to read file"));
+      reader.readAsDataURL(file);
+    });
+  };
+
   const handleSignup = async () => {
     if (!username || !password) {
       setError("Username and password are required.");
       return;
     }
 
-    // Simulate saving additional data
-    console.log("Signup Data:", { username, password, position, age, image });
+    // Convert image file to base64 if provided
+    let imageData: string | null = null;
+    if (image) {
+      try {
+        imageData = await fileToDataUrl(image);
+      } catch (err) {
+        console.error(err);
+      }
+    }
 
-    const ok = await signup(username, password);
+    const ok = await signup(
+      username,
+      password,
+      position,
+      Number(age),
+      imageData
+    );
     if (ok) {
       router.push("/signin");
     } else {

--- a/models/User.ts
+++ b/models/User.ts
@@ -7,6 +7,12 @@ const UserSchema = new Schema({
   username: { type: String, required: true, unique: true },
   // Hashed password value
   password: { type: String, required: true },
+  // Position or title of the user
+  position: { type: String },
+  // Numeric age of the user
+  age: { type: Number },
+  // Base64 encoded image string
+  image: { type: String },
 });
 
 // Reuse the model if it has already been compiled


### PR DESCRIPTION
## Summary
- extend User model to hold profile info
- save position, age and image when signing up
- allow client signup form to send profile data
- update auth context to handle new signup fields

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc --noEmit` *(fails: cannot find module declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6854c0d5f008832690d3b36693384afc