### PR TITLE
Fix signup parameters and cleanup

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -19,7 +19,7 @@ export default function HomePage() {
         .then((data) => setUsers(data.users ?? []))
         .catch(() => setUsers([]));
     }
-  }, [user, loading]);
+  }, [user, loading, router]);
 
   if (loading || !user)
     return <div className="text-center mt-5">Loading...</div>;

--- a/app/logout/page.tsx
+++ b/app/logout/page.tsx
@@ -10,7 +10,7 @@ export default function LogoutPage() {
   useEffect(() => {
     logout();
     router.push("/signin");
-  }, []);
+  }, [logout, router]);
 
   return <div>Logging out...</div>;
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,7 +7,7 @@ export default function Page() {
 
   useEffect(() => {
     router.push("/signin");
-  }, []);
+  }, [router]);
 
   return <div>Redirecting...</div>;
 }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -20,10 +20,32 @@ export default function SignupPage() {
       return;
     }
 
-    // Simulate saving additional data
-    console.log("Signup Data:", { username, password, position, age, image });
+    // Prepare optional base64 encoded image string
+    let imageData: string | null = null;
+    if (image) {
+      imageData = await new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result as string);
+        reader.onerror = () => reject(new Error("Failed to read image"));
+        reader.readAsDataURL(image);
+      });
+    }
 
-    const ok = await signup(username, password);
+    console.log("Signup Data:", {
+      username,
+      password,
+      position,
+      age,
+      image: imageData,
+    });
+
+    const ok = await signup(
+      username,
+      password,
+      position,
+      Number(age),
+      imageData,
+    );
     if (ok) {
       router.push("/signin");
     } else {
@@ -72,18 +94,7 @@ export default function SignupPage() {
               className="form-control"
               value={position}
               onChange={(e) => setPosition(e.target.value)}
-              placeholder="Enter Department"
-            />
-          </div>
-
-          <div className="mb-3">
-            <label className="form-label">Position</label>
-            <input
-              type="text"
-              className="form-control"
-              value={position}
-              onChange={(e) => setPosition(e.target.value)}
-              placeholder="Enter Positon"
+              placeholder="Enter position"
             />
           </div>
 

--- a/lib/mongodb.ts
+++ b/lib/mongodb.ts
@@ -2,12 +2,7 @@
 import mongoose from 'mongoose';
 
 // Connection string to the MongoDB instance
-const MONGODB_URI = process.env.MONGODB_URI as string;
-
-// Ensure the connection string is defined at build time
-if (!MONGODB_URI) {
-  throw new Error('Please define the MONGODB_URI environment variable');
-}
+const MONGODB_URI = process.env.MONGODB_URI as string | undefined;
 
 // Shape of the cached connection object stored on the Node.js global
 interface MongooseCache {
@@ -19,7 +14,6 @@ interface MongooseCache {
 
 declare global {
   // Augment the global object to store the connection across reloads
-  // eslint-disable-next-line no-var
   var mongoose: MongooseCache | undefined;
 }
 
@@ -31,6 +25,10 @@ global.mongoose = cached;
 async function dbConnect() {
   // Reuse previous connection if it exists
   if (cached.conn) return cached.conn;
+
+  if (!MONGODB_URI) {
+    throw new Error('Please define the MONGODB_URI environment variable');
+  }
 
   // If a connection promise hasn't been created yet, start one
   if (!cached.promise) {


### PR DESCRIPTION
## Summary
- handle signup fields correctly and send extra data
- avoid build failure when MONGODB_URI is undefined
- include router dependencies in hooks
- remove duplicate form field and stale eslint directive

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6854cfec4764832680abae05419ea123