### PR TITLE
Display user info on home page

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -60,7 +60,25 @@ export default function HomePage() {
                     key={u.username}
                     className="list-group-item list-group-item-light"
                   >
-                    {u.username}
+                    <div className="d-flex align-items-center">
+                      {u.image && (
+                        <img
+                          src={u.image}
+                          alt={`${u.username} profile`}
+                          className="rounded-circle me-3"
+                          style={{ width: "50px", height: "50px", objectFit: "cover" }}
+                        />
+                      )}
+                      <div>
+                        <div className="fw-bold">{u.username}</div>
+                        {u.position && (
+                          <div className="text-muted">Position: {u.position}</div>
+                        )}
+                        {typeof u.age === "number" && (
+                          <div className="text-muted">Age: {u.age}</div>
+                        )}
+                      </div>
+                    </div>
                   </li>
                 ))}
               </ul>


### PR DESCRIPTION
## Summary
- show user details from MongoDB on the home page

## Testing
- `npm install`
- `npm run lint` *(fails: `Warning: Using <img> could result in slower LCP`)*

------
https://chatgpt.com/codex/tasks/task_e_6854d4fe28ac8326b81826239e522581