### PR TITLE
Enable editing and deleting users

### DIFF
--- a/app/api/users/[username]/route.ts
+++ b/app/api/users/[username]/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/mongodb';
+import User from '@/models/User';
+
+export async function GET(
+  req: Request,
+  { params }: { params: { username: string } }
+) {
+  await dbConnect();
+  const user = await User.findOne(
+    { username: params.username },
+    'username position age image -_id'
+  ).lean();
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+  return NextResponse.json({ user });
+}
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { username: string } }
+) {
+  const { position, age } = await req.json();
+  await dbConnect();
+  const user = await User.findOneAndUpdate(
+    { username: params.username },
+    { position, age },
+    { new: true, fields: 'username position age image -_id' }
+  ).lean();
+  if (!user) {
+    return NextResponse.json({ error: 'User not found' }, { status: 404 });
+  }
+  return NextResponse.json({ user });
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { username: string } }
+) {
+  await dbConnect();
+  await User.deleteOne({ username: params.username });
+  return NextResponse.json({ success: true });
+}

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -17,6 +17,37 @@ export default function HomePage() {
 
   const [users, setUsers] = useState<User[]>([]);
 
+  const handleDelete = async (username: string) => {
+    if (!confirm("Delete this user?")) return;
+    const res = await fetch(`/api/users/${username}`, {
+      method: "DELETE",
+    });
+    if (res.ok) {
+      setUsers((prev) => prev.filter((u) => u.username !== username));
+    }
+  };
+
+  const handleEdit = async (u: User) => {
+    const position = prompt("Position", u.position || "");
+    if (position === null) return;
+    const ageInput = prompt("Age", u.age?.toString() || "");
+    if (ageInput === null) return;
+    const age = Number(ageInput);
+    const res = await fetch(`/api/users/${u.username}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ position, age }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setUsers((prev) =>
+        prev.map((item) =>
+          item.username === u.username ? data.user : item
+        )
+      );
+    }
+  };
+
   useEffect(() => {
     if (loading) return;
 
@@ -83,10 +114,16 @@ export default function HomePage() {
                       </div>
 
                       <div className="btn-group">
-                        <button className="btn btn-sm btn-outline-primary">
+                        <button
+                          className="btn btn-sm btn-outline-primary"
+                          onClick={() => handleEdit(u)}
+                        >
                           Edit
                         </button>
-                        <button className="btn btn-sm btn-outline-danger">
+                        <button
+                          className="btn btn-sm btn-outline-danger"
+                          onClick={() => handleDelete(u.username)}
+                        >
                           Delete
                         </button>
                       </div>


### PR DESCRIPTION
## Summary
- add dynamic API route for editing or deleting individual users
- allow editing or deleting users from the home page via prompts

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6854d70dff448326922ecd6b9a086ce0