### PR TITLE
Allow editing all user fields

### DIFF
--- a/app/api/users/[username]/route.ts
+++ b/app/api/users/[username]/route.ts
@@ -21,16 +21,28 @@ export async function PUT(
   req: Request,
   { params }: { params: { username: string } }
 ) {
-  const { position, age } = await req.json();
+  // Extract potential updates from the request body
+  const { username, position, age, image } = await req.json();
+
   await dbConnect();
+
+  // Only include fields that were provided in the update payload
+  const update: Record<string, unknown> = {};
+  if (username !== undefined) update.username = username;
+  if (position !== undefined) update.position = position;
+  if (age !== undefined) update.age = age;
+  if (image !== undefined) update.image = image;
+
   const user = await User.findOneAndUpdate(
     { username: params.username },
-    { position, age },
+    update,
     { new: true, fields: 'username position age image -_id' }
   ).lean();
+
   if (!user) {
     return NextResponse.json({ error: 'User not found' }, { status: 404 });
   }
+
   return NextResponse.json({ user });
 }
 

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -28,15 +28,35 @@ export default function HomePage() {
   };
 
   const handleEdit = async (u: User) => {
+    const username = prompt("Username", u.username);
+    if (username === null) return;
     const position = prompt("Position", u.position || "");
     if (position === null) return;
     const ageInput = prompt("Age", u.age?.toString() || "");
     if (ageInput === null) return;
     const age = Number(ageInput);
+    const changeImage = confirm("Change image?");
+    let image = u.image;
+    if (changeImage) {
+      image = await new Promise<string | null>((resolve) => {
+        const input = document.createElement("input");
+        input.type = "file";
+        input.accept = "image/*";
+        input.onchange = () => {
+          const file = input.files?.[0];
+          if (!file) return resolve(null);
+          const reader = new FileReader();
+          reader.onload = () => resolve(reader.result as string);
+          reader.onerror = () => resolve(null);
+          reader.readAsDataURL(file);
+        };
+        input.click();
+      });
+    }
     const res = await fetch(`/api/users/${u.username}`, {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ position, age }),
+      body: JSON.stringify({ username, position, age, image }),
     });
     if (res.ok) {
       const data = await res.json();


### PR DESCRIPTION
## Summary
- update PUT user API endpoint to allow editing username, position, age and image
- enhance Home page's Edit button handler to prompt for username and image updates

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854db3b6bac83269ec78c2caaecdc3e