### PR TITLE
Add chat page and message button link

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -1,0 +1,15 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+
+export default function ChatPage() {
+  const searchParams = useSearchParams();
+  const user = searchParams.get("user") ?? "";
+
+  return (
+    <div className="p-4">
+      <h1 className="h3 mb-4">Chat {user && `with ${user}`}</h1>
+      <p>This is the chat page.</p>
+    </div>
+  );
+}

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -194,7 +194,7 @@ export default function HomePage() {
                       <div className="btn-group">
                         <button
                           className="btn btn-sm btn-outline-secondary"
-                          onClick={() => alert(`Message to ${u.username}`)}
+                          onClick={() => router.push(`/chat?user=${u.username}`)}
                         >
                           <i className="bi bi-chat-dots me-1"></i> Message
                         </button>


### PR DESCRIPTION
## Summary
- enable message buttons to link to `/chat` with selected user
- scaffold a simple chat page that shows which user is being chatted with

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856ca07e8a08326a226a9efb1daadac