### PR TITLE
Add chat message persistence with MongoDB

### DIFF
--- a/app/api/messages/route.ts
+++ b/app/api/messages/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/mongodb';
+import Message from '@/models/Message';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const user1 = searchParams.get('user1');
+  const user2 = searchParams.get('user2');
+
+  if (!user1 || !user2) {
+    return NextResponse.json({ error: 'Missing users' }, { status: 400 });
+  }
+
+  await dbConnect();
+  const messages = await Message.find({
+    $or: [
+      { from: user1, to: user2 },
+      { from: user2, to: user1 },
+    ],
+  })
+    .sort({ createdAt: 1 })
+    .lean();
+
+  return NextResponse.json({ messages });
+}
+
+export async function POST(req: Request) {
+  const { from, to, type, content, fileName } = await req.json();
+  await dbConnect();
+  const message = await Message.create({ from, to, type, content, fileName });
+  return NextResponse.json({ message });
+}
+

--- a/models/Message.ts
+++ b/models/Message.ts
@@ -1,0 +1,13 @@
+import { Schema, model, models } from 'mongoose';
+
+const MessageSchema = new Schema({
+  from: { type: String, required: true },
+  to: { type: String, required: true },
+  type: { type: String, enum: ['text', 'image', 'file'], required: true },
+  content: { type: String, required: true },
+  fileName: { type: String },
+  createdAt: { type: Date, default: Date.now },
+});
+
+export default models.Message || model('Message', MessageSchema);
+


### PR DESCRIPTION
## Summary
- introduce `Message` Mongoose model
- add REST API for chat messages
- persist chat messages to database and fetch them on Chat page

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6856d459ebe48326912abd55f401cb6e