### PR TITLE
Enable message deletion in chat

### DIFF
--- a/app/api/messages/[id]/route.ts
+++ b/app/api/messages/[id]/route.ts
@@ -1,0 +1,16 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/mongodb';
+import Message from '@/models/Message';
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  await dbConnect();
+  const message = await Message.findByIdAndDelete(params.id);
+  if (!message) {
+    return NextResponse.json({ error: 'Message not found' }, { status: 404 });
+  }
+  return NextResponse.json({ success: true });
+}
+


### PR DESCRIPTION
## Summary
- allow deletion of chat messages via new API route
- send and receive messages with IDs
- handle deleting messages client side

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68577f47bcb08326a190fdee7bd2e7ec