### PR TITLE
Add basic placeholder pages

### DIFF
--- a/app/analysis/page.tsx
+++ b/app/analysis/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../context/AuthContext";
+
+export default function AnalysisPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/signin");
+    }
+  }, [loading, user, router]);
+
+  if (loading || !user) return <div className="text-center mt-5">Loading...</div>;
+
+  return (
+    <div className="container-fluid min-vh-100 bg-light p-4">
+      {/* Top bar */}
+      <div className="d-flex justify-content-between align-items-center mb-4">
+        <h2 className="mb-0">Analysis</h2>
+        <div className="d-flex align-items-center gap-3">
+          <span className="fw-semibold">{user.username}</span>
+          <a href="/logout" className="btn btn-sm btn-outline-danger">
+            Log Out
+          </a>
+        </div>
+      </div>
+
+      {/* Menu bar */}
+      <div className="mb-4">
+        <ul className="nav nav-pills gap-2">
+          <li className="nav-item">
+            <a className="nav-link" href="/home">Home</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/posts">All Post</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/user">User</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link active" href="/analysis">Analysis</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/setting">Setting</a>
+          </li>
+        </ul>
+      </div>
+
+      {/* Content */}
+      <div className="card shadow-sm w-100 mx-auto" style={{ maxWidth: "100%" }}>
+        <div className="card-body">
+          <p className="text-muted text-center">Analysis page coming soon.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -128,19 +128,19 @@ export default function HomePage() {
       <div className="mb-4">
         <ul className="nav nav-pills gap-2">
           <li className="nav-item">
-            <a className="nav-link active" href="#">Home</a>
+            <a className="nav-link active" href="/home">Home</a>
           </li>
           <li className="nav-item">
-            <a className="nav-link" href="#">All Post</a>
+            <a className="nav-link" href="/posts">All Post</a>
           </li>
           <li className="nav-item">
-            <a className="nav-link" href="#">User</a>
+            <a className="nav-link" href="/user">User</a>
           </li>
           <li className="nav-item">
-            <a className="nav-link" href="#">Analysis</a>
+            <a className="nav-link" href="/analysis">Analysis</a>
           </li>
           <li className="nav-item">
-            <a className="nav-link" href="#">Setting</a>
+            <a className="nav-link" href="/setting">Setting</a>
           </li>
         </ul>
       </div>

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../context/AuthContext";
+
+export default function PostsPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/signin");
+    }
+  }, [loading, user, router]);
+
+  if (loading || !user) return <div className="text-center mt-5">Loading...</div>;
+
+  return (
+    <div className="container-fluid min-vh-100 bg-light p-4">
+      {/* Top bar */}
+      <div className="d-flex justify-content-between align-items-center mb-4">
+        <h2 className="mb-0">All Post</h2>
+        <div className="d-flex align-items-center gap-3">
+          <span className="fw-semibold">{user.username}</span>
+          <a href="/logout" className="btn btn-sm btn-outline-danger">
+            Log Out
+          </a>
+        </div>
+      </div>
+
+      {/* Menu bar */}
+      <div className="mb-4">
+        <ul className="nav nav-pills gap-2">
+          <li className="nav-item">
+            <a className="nav-link" href="/home">Home</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link active" href="/posts">All Post</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/user">User</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/analysis">Analysis</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/setting">Setting</a>
+          </li>
+        </ul>
+      </div>
+
+      {/* Content */}
+      <div className="card shadow-sm w-100 mx-auto" style={{ maxWidth: "100%" }}>
+        <div className="card-body">
+          <p className="text-muted text-center">Post page coming soon.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/setting/page.tsx
+++ b/app/setting/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../context/AuthContext";
+
+export default function SettingPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/signin");
+    }
+  }, [loading, user, router]);
+
+  if (loading || !user) return <div className="text-center mt-5">Loading...</div>;
+
+  return (
+    <div className="container-fluid min-vh-100 bg-light p-4">
+      {/* Top bar */}
+      <div className="d-flex justify-content-between align-items-center mb-4">
+        <h2 className="mb-0">Setting</h2>
+        <div className="d-flex align-items-center gap-3">
+          <span className="fw-semibold">{user.username}</span>
+          <a href="/logout" className="btn btn-sm btn-outline-danger">
+            Log Out
+          </a>
+        </div>
+      </div>
+
+      {/* Menu bar */}
+      <div className="mb-4">
+        <ul className="nav nav-pills gap-2">
+          <li className="nav-item">
+            <a className="nav-link" href="/home">Home</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/posts">All Post</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/user">User</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/analysis">Analysis</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link active" href="/setting">Setting</a>
+          </li>
+        </ul>
+      </div>
+
+      {/* Content */}
+      <div className="card shadow-sm w-100 mx-auto" style={{ maxWidth: "100%" }}>
+        <div className="card-body">
+          <p className="text-muted text-center">Setting page coming soon.</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../context/AuthContext";
+
+export default function UserPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/signin");
+    }
+  }, [loading, user, router]);
+
+  if (loading || !user) return <div className="text-center mt-5">Loading...</div>;
+
+  return (
+    <div className="container-fluid min-vh-100 bg-light p-4">
+      {/* Top bar */}
+      <div className="d-flex justify-content-between align-items-center mb-4">
+        <h2 className="mb-0">User</h2>
+        <div className="d-flex align-items-center gap-3">
+          <span className="fw-semibold">{user.username}</span>
+          <a href="/logout" className="btn btn-sm btn-outline-danger">
+            Log Out
+          </a>
+        </div>
+      </div>
+
+      {/* Menu bar */}
+      <div className="mb-4">
+        <ul className="nav nav-pills gap-2">
+          <li className="nav-item">
+            <a className="nav-link" href="/home">Home</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/posts">All Post</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link active" href="/user">User</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/analysis">Analysis</a>
+          </li>
+          <li className="nav-item">
+            <a className="nav-link" href="/setting">Setting</a>
+          </li>
+        </ul>
+      </div>
+
+      {/* Content */}
+      <div className="card shadow-sm w-100 mx-auto" style={{ maxWidth: "100%" }}>
+        <div className="card-body">
+          <p className="text-muted text-center">User page coming soon.</p>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create new pages: posts, user, analysis and setting
- link these pages from the Home menu

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6858b0fa64d483268def4773b89e8cc1