### PR TITLE
Enable blog persistence in create page

### DIFF
--- a/app/create-blog/page.tsx
+++ b/app/create-blog/page.tsx
@@ -31,9 +31,11 @@ export default function CreateBlogPage() {
       image,
     };
 
-    console.log("Submitting blog post:", postData);
-    alert("Blog post submitted! (replace with real logic)");
-    // TODO: Send postData to your backend API
+    // Persist the latest blog in localStorage so the home page can display it
+    localStorage.setItem("latest_blog", JSON.stringify(postData));
+
+    // Redirect back to the home page where the post will be visible
+    router.push("/home");
   };
 
   return (


### PR DESCRIPTION
## Summary
- persist newly created blogs in localStorage

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: index defined but never used, warnings about `<img>`)*

------
https://chatgpt.com/codex/tasks/task_e_6858d9375c6c8326a0f98c73c63241a7