### PR TITLE
Persist comments to MongoDB

### DIFF
--- a/app/api/comments/[id]/route.ts
+++ b/app/api/comments/[id]/route.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/mongodb';
+import Comment from '@/models/Comment';
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const { author, text } = await req.json();
+  await dbConnect();
+  const comment = await Comment.findByIdAndUpdate(
+    params.id,
+    { $push: { replies: { author, text } } },
+    { new: true }
+  ).lean();
+  if (!comment) {
+    return NextResponse.json({ error: 'Comment not found' }, { status: 404 });
+  }
+  return NextResponse.json({ comment });
+}
+

--- a/app/api/comments/route.ts
+++ b/app/api/comments/route.ts
@@ -1,0 +1,27 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/mongodb';
+import Comment from '@/models/Comment';
+
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const postId = searchParams.get('postId');
+  if (!postId) {
+    return NextResponse.json({ error: 'Missing postId' }, { status: 400 });
+  }
+
+  await dbConnect();
+  const comments = await Comment.find({ postId }).sort({ createdAt: 1 }).lean();
+  return NextResponse.json({ comments });
+}
+
+export async function POST(req: Request) {
+  const { postId, author, text } = await req.json();
+  await dbConnect();
+  try {
+    const comment = await Comment.create({ postId, author, text });
+    return NextResponse.json({ comment });
+  } catch {
+    return NextResponse.json({ error: 'Failed to create comment' }, { status: 400 });
+  }
+}
+

--- a/app/components/BlogCard.tsx
+++ b/app/components/BlogCard.tsx
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
+import { useAuth } from "../context/AuthContext";
 
 interface BlogPost {
+  _id?: string;
   title: string;
   content: string;
   image: string | null;
@@ -14,11 +16,18 @@ interface AuthorData {
   image?: string;
 }
 
+interface Reply {
+  author: string;
+  text: string;
+}
+
 interface Comment {
+  _id: string;
+  author: string;
   text: string;
   likes: number;
   dislikes: number;
-  replies: string[];
+  replies: Reply[];
   showReplyInput: boolean;
   newReply: string;
 }
@@ -26,10 +35,13 @@ interface Comment {
 export default function BlogCard({
   blog,
   author,
+  users,
 }: {
   blog: BlogPost;
   author?: AuthorData;
+  users?: AuthorData[];
 }) {
+  const { user } = useAuth();
   const [likes, setLikes] = useState(0);
   const [dislikes, setDislikes] = useState(0);
   const [comments, setComments] = useState<Comment[]>([]);
@@ -38,20 +50,40 @@ export default function BlogCard({
   const [showCommentsModal, setShowCommentsModal] = useState(false);
   const [showImageModal, setShowImageModal] = useState(false);
 
-  const handleCommentSubmit = () => {
-    if (newComment.trim() !== "") {
+  useEffect(() => {
+    if (!blog._id) return;
+    fetch(`/api/comments?postId=${blog._id}`)
+      .then((res) => res.json())
+      .then((data) => {
+        const mapped = (data.comments || []).map((c: any) => ({
+          ...c,
+          showReplyInput: false,
+          newReply: '',
+        }));
+        setComments(mapped);
+      })
+      .catch(() => setComments([]));
+  }, [blog._id]);
+
+  const handleCommentSubmit = async () => {
+    if (!user || !newComment.trim() || !blog._id) return;
+
+    const res = await fetch('/api/comments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        postId: blog._id,
+        author: user.username,
+        text: newComment.trim(),
+      }),
+    });
+    if (res.ok) {
+      const data = await res.json();
       setComments((prev) => [
         ...prev,
-        {
-          text: newComment.trim(),
-          likes: 0,
-          dislikes: 0,
-          replies: [],
-          showReplyInput: false,
-          newReply: "",
-        },
+        { ...data.comment, showReplyInput: false, newReply: '' },
       ]);
-      setNewComment("");
+      setNewComment('');
     }
   };
 
@@ -81,19 +113,25 @@ export default function BlogCard({
     );
   };
 
-  const handleReplySubmit = (index: number) => {
-    setComments((prev) =>
-      prev.map((c, i) =>
-        i === index && c.newReply.trim()
-          ? {
-              ...c,
-              replies: [...c.replies, c.newReply.trim()],
-              newReply: "",
-              showReplyInput: false,
-            }
-          : c
-      )
-    );
+  const handleReplySubmit = async (index: number) => {
+    const c = comments[index];
+    if (!c || !c.newReply.trim() || !user) return;
+
+    const res = await fetch(`/api/comments/${c._id}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ author: user.username, text: c.newReply.trim() }),
+    });
+    if (res.ok) {
+      const data = await res.json();
+      setComments((prev) =>
+        prev.map((cm, i) =>
+          i === index
+            ? { ...data.comment, showReplyInput: false, newReply: '' }
+            : cm
+        )
+      );
+    }
   };
 
   return (
@@ -175,9 +213,22 @@ export default function BlogCard({
                 className="mb-3"
               >
                 <ul className="list-group">
-                  {(showAllComments ? comments : comments.slice(-3)).map((comment, idx) => (
+                  {(showAllComments ? comments : comments.slice(-3)).map((comment, idx) => {
+                    const commentAuthor = users?.find((u) => u.username === comment.author);
+                    return (
                     <li key={idx} className="list-group-item mb-3 rounded shadow-sm bg-white">
                       <div className="d-flex justify-content-between align-items-center">
+                        <div className="d-flex align-items-center gap-2">
+                          {commentAuthor?.image && (
+                            <img
+                              src={commentAuthor.image}
+                              alt={commentAuthor.username}
+                              className="rounded-circle"
+                              style={{ width: '30px', height: '30px', objectFit: 'cover' }}
+                            />
+                          )}
+                          <strong>{comment.author}</strong>
+                        </div>
                         <span>{comment.text}</span>
                         <div className="btn-group btn-group-sm">
                           <button className="btn btn-outline-success" onClick={() => handleLikeComment(idx)}>
@@ -195,11 +246,24 @@ export default function BlogCard({
                       {/* Replies */}
                       {comment.replies.length > 0 && (
                         <ul className="mt-2 ps-3 list-unstyled">
-                          {comment.replies.map((reply, rIdx) => (
-                            <li key={rIdx} className="text-muted small mb-2">
-                              ↪ {reply}
-                            </li>
-                          ))}
+                          {comment.replies.map((reply, rIdx) => {
+                            const rAuthor = users?.find((u) => u.username === reply.author);
+                            return (
+                              <li key={rIdx} className="text-muted small mb-2 d-flex align-items-center gap-2">
+                                {rAuthor?.image && (
+                                  <img
+                                    src={rAuthor.image}
+                                    alt={reply.author}
+                                    className="rounded-circle"
+                                    style={{ width: '24px', height: '24px', objectFit: 'cover' }}
+                                  />
+                                )}
+                                <span>
+                                  ↪ <strong>{reply.author}</strong>: {reply.text}
+                                </span>
+                              </li>
+                            );
+                          })}
                         </ul>
                       )}
 
@@ -273,9 +337,22 @@ export default function BlogCard({
               {/* Scrollable Comments */}
               <div className="modal-body" style={{ overflowY: "auto", flexGrow: 1, paddingRight: "10px" }}>
                 <ul className="list-group">
-                  {comments.map((comment, idx) => (
+                  {comments.map((comment, idx) => {
+                    const cAuthor = users?.find((u) => u.username === comment.author);
+                    return (
                     <li key={idx} className="list-group-item mb-3 rounded shadow-sm bg-white">
                       <div className="d-flex justify-content-between align-items-center">
+                        <div className="d-flex align-items-center gap-2">
+                          {cAuthor?.image && (
+                            <img
+                              src={cAuthor.image}
+                              alt={cAuthor.username}
+                              className="rounded-circle"
+                              style={{ width: '30px', height: '30px', objectFit: 'cover' }}
+                            />
+                          )}
+                          <strong>{comment.author}</strong>
+                        </div>
                         <span>{comment.text}</span>
                         <div className="btn-group btn-group-sm">
                           <button className="btn btn-outline-success" onClick={() => handleLikeComment(idx)}>
@@ -293,11 +370,24 @@ export default function BlogCard({
                       {/* Replies */}
                       {comment.replies.length > 0 && (
                         <ul className="mt-2 ps-3 list-unstyled">
-                          {comment.replies.map((reply, rIdx) => (
-                            <li key={rIdx} className="text-muted small mb-2">
-                              ↪ {reply}
-                            </li>
-                          ))}
+                          {comment.replies.map((reply, rIdx) => {
+                            const rAuthor = users?.find((u) => u.username === reply.author);
+                            return (
+                              <li key={rIdx} className="text-muted small mb-2 d-flex align-items-center gap-2">
+                                {rAuthor?.image && (
+                                  <img
+                                    src={rAuthor.image}
+                                    alt={reply.author}
+                                    className="rounded-circle"
+                                    style={{ width: '24px', height: '24px', objectFit: 'cover' }}
+                                  />
+                                )}
+                                <span>
+                                  ↪ <strong>{reply.author}</strong>: {reply.text}
+                                </span>
+                              </li>
+                            );
+                          })}
                         </ul>
                       )}
 

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -101,6 +101,7 @@ export default function HomePage() {
                 key={post._id ?? post.title}
                 blog={post}
                 author={author}
+                users={users}
               />
             );
           })

--- a/models/Comment.ts
+++ b/models/Comment.ts
@@ -1,0 +1,24 @@
+import { Schema, model, models } from 'mongoose';
+
+const ReplySchema = new Schema(
+  {
+    author: { type: String, required: true },
+    text: { type: String, required: true },
+  },
+  { _id: false, timestamps: true }
+);
+
+const CommentSchema = new Schema(
+  {
+    postId: { type: Schema.Types.ObjectId, ref: 'Post', required: true },
+    author: { type: String, required: true },
+    text: { type: String, required: true },
+    likes: { type: Number, default: 0 },
+    dislikes: { type: Number, default: 0 },
+    replies: { type: [ReplySchema], default: [] },
+  },
+  { timestamps: true }
+);
+
+export default models.Comment || model('Comment', CommentSchema);
+


### PR DESCRIPTION
## Summary
- create Comment model
- add `/api/comments` routes for creating and fetching comments
- add `/api/comments/[id]` route for posting replies
- integrate BlogCard with new APIs
- display commenter image and username

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685a29170158832685ba9c758665dd7a