### PR TITLE
Fix JSX syntax in BlogCard component

### DIFF
--- a/app/components/BlogCard.tsx
+++ b/app/components/BlogCard.tsx
@@ -283,7 +283,8 @@ export default function BlogCard({
                         </div>
                       )}
                     </li>
-                  ))}
+                    );
+                  })}
                 </ul>
               </div>
 
@@ -407,7 +408,8 @@ export default function BlogCard({
                         </div>
                       )}
                     </li>
-                  ))}
+                    );
+                  })}
                 </ul>
               </div>
 


### PR DESCRIPTION
## Summary
- resolve syntax errors in `BlogCard.tsx`

## Testing
- `npx tsc --noEmit app/components/BlogCard.tsx` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_e_685a2f8baa6483269e53bdfbb35fe2aa