### PR TITLE
Fix BlogCard syntax error

### DIFF
--- a/app/components/BlogCard.tsx
+++ b/app/components/BlogCard.tsx
@@ -219,8 +219,7 @@ export default function BlogCard({
                         </div>
                       )}
                     </li>
-                    );
-                  })}
+                  ))}
                 </ul>
               </div>
 
@@ -318,8 +317,7 @@ export default function BlogCard({
                         </div>
                       )}
                     </li>
-                    );
-                  })}
+                  ))}
                 </ul>
               </div>
 


### PR DESCRIPTION
## Summary
- fix missing closing parentheses when mapping comments

## Testing
- `npm run lint` *(fails: setShowAllComments is unused)*
- `npx tsc --noEmit` *(fails: other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_685a36905c508326a0582735c89fefc2