### PR TITLE
Add persistent like/dislike for posts and comments

### DIFF
--- a/app/api/comments/[id]/route.ts
+++ b/app/api/comments/[id]/route.ts
@@ -19,3 +19,20 @@ export async function POST(
   return NextResponse.json({ comment });
 }
 
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const { action } = await req.json();
+  if (!['like', 'dislike'].includes(action)) {
+    return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
+  }
+  await dbConnect();
+  const update = action === 'like' ? { $inc: { likes: 1 } } : { $inc: { dislikes: 1 } };
+  const comment = await Comment.findByIdAndUpdate(params.id, update, { new: true }).lean();
+  if (!comment) {
+    return NextResponse.json({ error: 'Comment not found' }, { status: 404 });
+  }
+  return NextResponse.json({ comment });
+}
+

--- a/app/api/posts/[id]/route.ts
+++ b/app/api/posts/[id]/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from 'next/server';
+import dbConnect from '@/lib/mongodb';
+import Post from '@/models/Post';
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const { action } = await req.json();
+  if (!['like', 'dislike'].includes(action)) {
+    return NextResponse.json({ error: 'Invalid action' }, { status: 400 });
+  }
+  await dbConnect();
+  const update = action === 'like' ? { $inc: { likes: 1 } } : { $inc: { dislikes: 1 } };
+  const post = await Post.findByIdAndUpdate(params.id, update, { new: true }).lean();
+  if (!post) {
+    return NextResponse.json({ error: 'Post not found' }, { status: 404 });
+  }
+  return NextResponse.json({ post });
+}

--- a/app/components/BlogCard.tsx
+++ b/app/components/BlogCard.tsx
@@ -9,6 +9,8 @@ interface BlogPost {
   content: string;
   image: string | null;
   author: string;
+  likes: number;
+  dislikes: number;
 }
 
 interface AuthorData {
@@ -41,8 +43,8 @@ export default function BlogCard({
   blog: BlogPost;
   author?: AuthorData;
 }) {
-  const [likes, setLikes] = useState(0);
-  const [dislikes, setDislikes] = useState(0);
+  const [likes, setLikes] = useState(blog.likes);
+  const [dislikes, setDislikes] = useState(blog.dislikes);
   const [comments, setComments] = useState<Comment[]>([]);
   const [newComment, setNewComment] = useState("");
   const [showAllComments, setShowAllComments] = useState(false);
@@ -50,6 +52,11 @@ export default function BlogCard({
   const [showImageModal, setShowImageModal] = useState(false);
   const [userImages, setUserImages] = useState<Record<string, string>>({});
   const { user } = useAuth();
+
+  useEffect(() => {
+    setLikes(blog.likes);
+    setDislikes(blog.dislikes);
+  }, [blog.likes, blog.dislikes]);
 
   useEffect(() => {
     if (!blog._id) return;
@@ -143,16 +150,32 @@ export default function BlogCard({
     ]);
   };
 
-  const handleLikeComment = (index: number) => {
+  const handleLikeComment = async (index: number) => {
+    const comment = comments[index];
     setComments((prev) =>
       prev.map((c, i) => (i === index ? { ...c, likes: c.likes + 1 } : c))
     );
+    if (comment._id) {
+      await fetch(`/api/comments/${comment._id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'like' }),
+      });
+    }
   };
 
-  const handleDislikeComment = (index: number) => {
+  const handleDislikeComment = async (index: number) => {
+    const comment = comments[index];
     setComments((prev) =>
       prev.map((c, i) => (i === index ? { ...c, dislikes: c.dislikes + 1 } : c))
     );
+    if (comment._id) {
+      await fetch(`/api/comments/${comment._id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'dislike' }),
+      });
+    }
   };
 
   const toggleReplyInput = (index: number) => {
@@ -261,13 +284,31 @@ export default function BlogCard({
         <div className="d-flex gap-3 align-items-center mt-3">
           <button
             className="btn btn-outline-success"
-            onClick={() => setLikes(likes + 1)}
+            onClick={async () => {
+              setLikes(likes + 1);
+              if (blog._id) {
+                await fetch(`/api/posts/${blog._id}`, {
+                  method: 'PATCH',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ action: 'like' }),
+                });
+              }
+            }}
           >
             👍 {likes}
           </button>
           <button
             className="btn btn-outline-danger"
-            onClick={() => setDislikes(dislikes + 1)}
+            onClick={async () => {
+              setDislikes(dislikes + 1);
+              if (blog._id) {
+                await fetch(`/api/posts/${blog._id}`, {
+                  method: 'PATCH',
+                  headers: { 'Content-Type': 'application/json' },
+                  body: JSON.stringify({ action: 'dislike' }),
+                });
+              }
+            }}
           >
             👎 {dislikes}
           </button>

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -19,6 +19,8 @@ interface BlogPost {
   content: string;
   image: string | null;
   author: string;
+  likes: number;
+  dislikes: number;
 }
 
 

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -18,6 +18,8 @@ interface BlogPost {
   content: string;
   image?: string | null;
   author: string;
+  likes: number;
+  dislikes: number;
 }
 
 export default function PostsPage() {

--- a/models/Post.ts
+++ b/models/Post.ts
@@ -6,6 +6,8 @@ const PostSchema = new Schema(
     content: { type: String, required: true },
     image: { type: String },
     author: { type: String, required: true },
+    likes: { type: Number, default: 0 },
+    dislikes: { type: Number, default: 0 },
   },
   { timestamps: true }
 );


### PR DESCRIPTION
## Summary
- extend Post model with `likes` and `dislikes`
- allow updating post reactions via new `/api/posts/[id]` route
- allow updating comment reactions via PATCH method
- sync BlogCard with backend when liking/disliking posts or comments
- expose reaction counts in blog post interfaces

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: many missing type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685a422f5ed483268d68430b53b47ea8