### PR TITLE
Update patch route response and handle in BlogCard

### DIFF
--- a/app/api/posts/[id]/route.ts
+++ b/app/api/posts/[id]/route.ts
@@ -16,5 +16,12 @@ export async function PATCH(
   if (!post) {
     return NextResponse.json({ error: 'Post not found' }, { status: 404 });
   }
-  return NextResponse.json({ post });
+  // Only return the updated like/dislike counts along with the post ID
+  return NextResponse.json({
+    post: {
+      _id: post._id,
+      likes: post.likes,
+      dislikes: post.dislikes,
+    },
+  });
 }

--- a/app/components/BlogCard.tsx
+++ b/app/components/BlogCard.tsx
@@ -285,13 +285,29 @@ export default function BlogCard({
           <button
             className="btn btn-outline-success"
             onClick={async () => {
+              const originalLikes = likes;
               setLikes(likes + 1);
               if (blog._id) {
-                await fetch(`/api/posts/${blog._id}`, {
-                  method: 'PATCH',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ action: 'like' }),
-                });
+                try {
+                  const res = await fetch(`/api/posts/${blog._id}`, {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'like' }),
+                  });
+                  if (res.ok) {
+                    const data = await res.json();
+                    if (data.post) {
+                      setLikes(data.post.likes);
+                      setDislikes(data.post.dislikes);
+                    }
+                  } else {
+                    setLikes(originalLikes);
+                    alert('Failed to like the post');
+                  }
+                } catch {
+                  setLikes(originalLikes);
+                  alert('Failed to like the post');
+                }
               }
             }}
           >
@@ -300,13 +316,29 @@ export default function BlogCard({
           <button
             className="btn btn-outline-danger"
             onClick={async () => {
+              const originalDislikes = dislikes;
               setDislikes(dislikes + 1);
               if (blog._id) {
-                await fetch(`/api/posts/${blog._id}`, {
-                  method: 'PATCH',
-                  headers: { 'Content-Type': 'application/json' },
-                  body: JSON.stringify({ action: 'dislike' }),
-                });
+                try {
+                  const res = await fetch(`/api/posts/${blog._id}`, {
+                    method: 'PATCH',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ action: 'dislike' }),
+                  });
+                  if (res.ok) {
+                    const data = await res.json();
+                    if (data.post) {
+                      setLikes(data.post.likes);
+                      setDislikes(data.post.dislikes);
+                    }
+                  } else {
+                    setDislikes(originalDislikes);
+                    alert('Failed to dislike the post');
+                  }
+                } catch {
+                  setDislikes(originalDislikes);
+                  alert('Failed to dislike the post');
+                }
               }
             }}
           >


### PR DESCRIPTION
## Summary
- return only the updated like/dislike counts from the `PATCH /api/posts/[id]` endpoint
- update BlogCard to use the returned counts and revert state on failure

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685a477a72ac8326a7d8cbc00cf3c4d8