### PR TITLE
Fix default like/dislike values

### DIFF
--- a/app/components/BlogCard.tsx
+++ b/app/components/BlogCard.tsx
@@ -43,8 +43,8 @@ export default function BlogCard({
   blog: BlogPost;
   author?: AuthorData;
 }) {
-  const [likes, setLikes] = useState(blog.likes);
-  const [dislikes, setDislikes] = useState(blog.dislikes);
+  const [likes, setLikes] = useState(blog.likes ?? 0);
+  const [dislikes, setDislikes] = useState(blog.dislikes ?? 0);
   const [comments, setComments] = useState<Comment[]>([]);
   const [newComment, setNewComment] = useState("");
   const [showAllComments] = useState(false);
@@ -54,8 +54,8 @@ export default function BlogCard({
   const { user } = useAuth();
 
   useEffect(() => {
-    setLikes(blog.likes);
-    setDislikes(blog.dislikes);
+    setLikes(blog.likes ?? 0);
+    setDislikes(blog.dislikes ?? 0);
   }, [blog.likes, blog.dislikes]);
 
   useEffect(() => {
@@ -84,8 +84,8 @@ export default function BlogCard({
           text: c.text as string,
           author: c.author as string,
           authorImage: images[c.author],
-          likes: c.likes as number,
-          dislikes: c.dislikes as number,
+          likes: c.likes ?? 0,
+          dislikes: c.dislikes ?? 0,
           replies: (c.replies ?? []).map((r: { text: string; author: string }) => ({
             text: r.text as string,
             author: r.author as string,


### PR DESCRIPTION
## Summary
- prevent `NaN` in post like/dislike counts
- guard comment like/dislike values when parsing

## Testing
- `npm run lint`
- `npm run build` *(fails: invalid `POST` export in `app/api/comments/[id]/route.ts`)*

------
https://chatgpt.com/codex/tasks/task_e_685a63b779688326bdc85a4d77fdc763