### PR TITLE
Track comment likes per user

### DIFF
--- a/models/Comment.ts
+++ b/models/Comment.ts
@@ -15,6 +15,8 @@ const CommentSchema = new Schema(
     text: { type: String, required: true },
     likes: { type: Number, default: 0 },
     dislikes: { type: Number, default: 0 },
+    likedBy: { type: [String], default: [] },
+    dislikedBy: { type: [String], default: [] },
     replies: { type: [ReplySchema], default: [] },
   },
   { timestamps: true }


### PR DESCRIPTION
## Summary
- track who liked or disliked a comment
- block duplicate comment likes/dislikes
- disable comment like/dislike buttons when used

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b523e59608326821dc9c3dbcbba88