### PR TITLE
Filter posts by logged-in user

### DIFF
--- a/app/api/posts/route.ts
+++ b/app/api/posts/route.ts
@@ -13,8 +13,13 @@ export async function POST(req: Request) {
   }
 }
 
-export async function GET() {
+export async function GET(req: Request) {
+  const { searchParams } = new URL(req.url);
+  const author = searchParams.get('author');
+
   await dbConnect();
-  const posts = await Post.find().sort({ createdAt: -1 }).lean();
+
+  const query = author ? { author } : {};
+  const posts = await Post.find(query).sort({ createdAt: -1 }).lean();
   return NextResponse.json({ posts });
 }

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -43,7 +43,7 @@ export default function PostsPage() {
 
     Promise.all([
       fetch("/api/users").then((res) => res.json()),
-      fetch("/api/posts").then((res) => res.json()),
+      fetch(`/api/posts?author=${encodeURIComponent(user.username)}`).then((res) => res.json()),
     ])
       .then(([usersData, postsData]) => {
         setUsers(usersData.users ?? []);


### PR DESCRIPTION
## Summary
- support author query parameter in posts API
- fetch logged-in user's posts on the Posts page

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685b551f776883269b1c0e0884fd94a4