### PR TITLE
Use BlogCard on posts page

### DIFF
--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../context/AuthContext";
 import TopBar from "../components/TopBar";
+import BlogCard from "../components/BlogCard";
 
 interface User {
   username: string;
@@ -13,7 +14,7 @@ interface User {
 }
 
 interface BlogPost {
-  _id: string;
+  _id?: string;
   title: string;
   content: string;
   image?: string | null;
@@ -81,34 +82,16 @@ export default function PostsPage() {
             </div>
           </div>
         ) : (
-          <div className="row g-4">
-            {posts.map((post) => (
-              <div key={post._id} className="col-12">
-                <div className="card shadow-sm">
-                  <div className="card-body">
-                    <h5 className="card-title">{post.title}</h5>
-                    <h6 className="card-subtitle mb-2 text-muted">by {post.author}</h6>
-
-                    {post.image && (
-                      <img
-                        src={post.image}
-                        alt={post.title}
-                        className="img-fluid rounded mb-3"
-                        style={{ maxHeight: "300px", objectFit: "cover" }}
-                      />
-                    )}
-
-                    <p className="card-text">{post.content}</p>
-
-                    <div className="d-flex gap-3 align-items-center mt-3">
-                      <span className="badge bg-success">👍 {post.likes}</span>
-                      <span className="badge bg-danger">👎 {post.dislikes}</span>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
+          posts.map((post) => {
+            const author = users.find((u) => u.username === post.author);
+            return (
+              <BlogCard
+                key={post._id ?? post.title}
+                blog={post}
+                author={author}
+              />
+            );
+          })
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- display user's posts using the existing `BlogCard` component
- keep the post interface consistent with `BlogCard`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b76a760ac83269183a55ffcb2484e