### PR TITLE
Implement post deletion

### DIFF
--- a/app/api/posts/[id]/route.ts
+++ b/app/api/posts/[id]/route.ts
@@ -46,3 +46,15 @@ export async function PATCH(
     },
   });
 }
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  await dbConnect();
+  const post = await Post.findByIdAndDelete(params.id);
+  if (!post) {
+    return NextResponse.json({ error: 'Post not found' }, { status: 404 });
+  }
+  return NextResponse.json({ success: true });
+}

--- a/app/components/BlogCard.tsx
+++ b/app/components/BlogCard.tsx
@@ -43,9 +43,11 @@ interface Comment {
 export default function BlogCard({
   blog,
   author,
+  onDelete,
 }: {
   blog: BlogPost;
   author?: AuthorData;
+  onDelete?: (id: string) => void;
 }) {
   const { user } = useAuth();
   const [likes, setLikes] = useState<number>(blog.likes ?? 0);
@@ -62,6 +64,7 @@ export default function BlogCard({
   const [showAllComments] = useState(false);
   const [showCommentsModal, setShowCommentsModal] = useState(false);
   const [showImageModal, setShowImageModal] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const [userImages, setUserImages] = useState<Record<string, string>>({});
 
   useEffect(() => {
@@ -405,6 +408,17 @@ export default function BlogCard({
     }
   };
 
+  const handleDeletePost = async () => {
+    if (!blog._id || !user) return;
+    if (!confirm("Delete this post?")) return;
+    setIsDeleting(true);
+    const res = await fetch(`/api/posts/${blog._id}`, { method: "DELETE" });
+    if (res.ok) {
+      onDelete?.(blog._id);
+    }
+    setIsDeleting(false);
+  };
+
   return (
     <div
       className="card shadow-sm w-100 mx-auto mb-4"
@@ -475,6 +489,15 @@ export default function BlogCard({
           >
             🔗 Share
           </button>
+          {user?.username === blog.author && (
+            <button
+              className="btn btn-outline-danger"
+              onClick={handleDeletePost}
+              disabled={isDeleting}
+            >
+              🗑 Delete
+            </button>
+          )}
         </div>
 
         {/* Comments Section */}

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -33,6 +33,13 @@ export default function HomePage() {
   const [users, setUsers] = useState<User[]>([]);
   const [posts, setPosts] = useState<BlogPost[]>([]);
   const [isFetching, setIsFetching] = useState(true);
+  const handleDelete = async (id: string) => {
+    if (!confirm("Delete this post?")) return;
+    const res = await fetch(`/api/posts/${id}`, { method: "DELETE" });
+    if (res.ok) {
+      setPosts((prev) => prev.filter((p) => p._id !== id));
+    }
+  };
 
   useEffect(() => {
     if (!loading && !user) {
@@ -105,6 +112,7 @@ export default function HomePage() {
                 key={post._id ?? post.title}
                 blog={post}
                 author={author}
+                onDelete={handleDelete}
               />
             );
           })

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -32,6 +32,13 @@ export default function PostsPage() {
   const [users, setUsers] = useState<User[]>([]);
   const [isFetching, setIsFetching] = useState(true);
   const [posts, setPosts] = useState<BlogPost[]>([]);
+  const handleDelete = async (id: string) => {
+    if (!confirm("Delete this post?")) return;
+    const res = await fetch(`/api/posts/${id}`, { method: "DELETE" });
+    if (res.ok) {
+      setPosts((prev) => prev.filter((p) => p._id !== id));
+    }
+  };
 
   useEffect(() => {
     if (!loading && !user) {
@@ -89,6 +96,7 @@ export default function PostsPage() {
                 key={post._id ?? post.title}
                 blog={post}
                 author={author}
+                onDelete={handleDelete}
               />
             );
           })


### PR DESCRIPTION
## Summary
- add DELETE handler for `/api/posts/[id]`
- support deletion UI in `BlogCard`
- add delete callbacks on Posts and Home pages

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685b7925ee788326b244b4c054819897