### PR TITLE
Restrict comment reaction to single vote

### DIFF
--- a/app/api/comments/[id]/route.ts
+++ b/app/api/comments/[id]/route.ts
@@ -36,7 +36,7 @@ export async function PATCH(
   const alreadyLiked = existing.likedBy?.includes(username);
   const alreadyDisliked = existing.dislikedBy?.includes(username);
 
-  if ((action === 'like' && alreadyLiked) || (action === 'dislike' && alreadyDisliked)) {
+  if (alreadyLiked || alreadyDisliked) {
     return NextResponse.json({
       comment: {
         _id: existing._id,

--- a/app/components/BlogCard.tsx
+++ b/app/components/BlogCard.tsx
@@ -192,7 +192,12 @@ export default function BlogCard({
 
   const handleLikeComment = async (index: number) => {
     const comment = comments[index];
-    if (!user || comment.likedBy?.includes(user.username)) return;
+    if (
+      !user ||
+      comment.likedBy?.includes(user.username) ||
+      comment.dislikedBy?.includes(user.username)
+    )
+      return;
     setComments((prev) =>
       prev.map((c, i) =>
         i === index
@@ -239,7 +244,12 @@ export default function BlogCard({
 
   const handleDislikeComment = async (index: number) => {
     const comment = comments[index];
-    if (!user || comment.dislikedBy?.includes(user.username)) return;
+    if (
+      !user ||
+      comment.dislikedBy?.includes(user.username) ||
+      comment.likedBy?.includes(user.username)
+    )
+      return;
     setComments((prev) =>
       prev.map((c, i) =>
         i === index
@@ -556,14 +566,24 @@ export default function BlogCard({
                             <button
                               className="btn btn-outline-success"
                               onClick={() => handleLikeComment(idx)}
-                              disabled={user ? comment.likedBy?.includes(user.username) : true}
+                              disabled={
+                                user
+                                  ? comment.likedBy?.includes(user.username) ||
+                                    comment.dislikedBy?.includes(user.username)
+                                  : true
+                              }
                             >
                               👍 {comment.likes}
                             </button>
                             <button
                               className="btn btn-outline-danger"
                               onClick={() => handleDislikeComment(idx)}
-                              disabled={user ? comment.dislikedBy?.includes(user.username) : true}
+                              disabled={
+                                user
+                                  ? comment.likedBy?.includes(user.username) ||
+                                    comment.dislikedBy?.includes(user.username)
+                                  : true
+                              }
                             >
                               👎 {comment.dislikes}
                             </button>
@@ -787,14 +807,24 @@ export default function BlogCard({
                           <button
                             className="btn btn-outline-success"
                             onClick={() => handleLikeComment(idx)}
-                            disabled={user ? comment.likedBy?.includes(user.username) : true}
+                            disabled={
+                              user
+                                ? comment.likedBy?.includes(user.username) ||
+                                  comment.dislikedBy?.includes(user.username)
+                                : true
+                            }
                           >
                             👍 {comment.likes}
                           </button>
                           <button
                             className="btn btn-outline-danger"
                             onClick={() => handleDislikeComment(idx)}
-                            disabled={user ? comment.dislikedBy?.includes(user.username) : true}
+                            disabled={
+                              user
+                                ? comment.likedBy?.includes(user.username) ||
+                                  comment.dislikedBy?.includes(user.username)
+                                : true
+                            }
                           >
                             👎 {comment.dislikes}
                           </button>


### PR DESCRIPTION
## Summary
- prevent multiple reactions by same user on a comment
- disable like/dislike buttons after one reaction
- guard comment API so user only votes once

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b8974ddec832684f0d7bcaaf00fed