### PR TITLE
Add Friend page with nav support

### DIFF
--- a/app/components/TopBar.tsx
+++ b/app/components/TopBar.tsx
@@ -7,7 +7,7 @@ interface UserData {
 
 interface TopBarProps {
   title: string;
-  active: "home" | "posts" | "user" | "analysis" | "setting";
+  active: "home" | "posts" | "user" | "analysis" | "setting" | "friend";
   currentUser: UserData;
 }
 
@@ -55,6 +55,11 @@ export default function TopBar({ title, active, currentUser }: TopBarProps) {
           <li className="nav-item">
             <a className={`nav-link ${active === "analysis" ? "active" : ""}`} href="/analysis">
               Analysis
+            </a>
+          </li>
+          <li className="nav-item">
+            <a className={`nav-link ${active === "friend" ? "active" : ""}`} href="/friend">
+              Friends
             </a>
           </li>
           <li className="nav-item">

--- a/app/friend/page.tsx
+++ b/app/friend/page.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { useAuth } from "../context/AuthContext";
+import TopBar from "../components/TopBar";
+
+interface User {
+  username: string;
+  position: string;
+  age: number;
+  image: string;
+}
+
+export default function FriendPage() {
+  const { user, loading } = useAuth();
+  const router = useRouter();
+  const [users, setUsers] = useState<User[]>([]);
+  const [isFetching, setIsFetching] = useState(true);
+
+  useEffect(() => {
+    if (!loading && !user) {
+      router.push("/signin");
+    }
+  }, [loading, user, router]);
+
+  useEffect(() => {
+    if (!user) return;
+
+    fetch("/api/users")
+      .then((res) => res.json())
+      .then((data) => setUsers(data.users ?? []))
+      .catch(() => setUsers([]))
+      .finally(() => setIsFetching(false));
+  }, [user]);
+
+  if (loading || isFetching || !user) {
+    return <div className="text-center mt-5">Loading...</div>;
+  }
+
+  const currentUserData = users.find((u) => u.username === user.username);
+  if (!currentUserData) {
+    return <div className="text-center mt-5">Loading user data...</div>;
+  }
+
+  return (
+    <div className="container-fluid min-vh-100 bg-light p-4">
+      {/* Sticky Top Bar and Menu */}
+      <TopBar
+        title="Friend"
+        active="friend"
+        currentUser={{ username: currentUserData.username, image: currentUserData.image }}
+      />
+
+      {/* Content */}
+      <div className="card shadow-sm w-100 mx-auto" style={{ maxWidth: "100%", top: "10px" }}>
+        <div className="card-body">
+          <h5 className="text-muted text-center">Friend page coming soon.</h5>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add a placeholder Friend page
- extend `TopBar` active types and navigation menu

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b93b75cbc832687dea6e417a828ea