### PR TITLE
Implement profile update in settings

### DIFF
--- a/app/setting/page.tsx
+++ b/app/setting/page.tsx
@@ -73,9 +73,39 @@ export default function SettingPage() {
     return <div className="text-center mt-5">Loading...</div>;
   }
 
-  const handleSave = () => {
-    alert("Profile saved (functionality not yet implemented).");
-    // TODO: Replace with real PATCH API call to /api/users
+  const handleSave = async () => {
+    if (!user) return;
+
+    const res = await fetch(`/api/users/${user.username}`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        username,
+        age,
+        image,
+      }),
+    });
+
+    if (res.ok) {
+      const data = await res.json();
+      setUsers((prev) =>
+        prev.map((u) =>
+          u.username === currentUserData.username ? data.user : u
+        )
+      );
+
+      if (username !== currentUserData.username) {
+        localStorage.setItem("user", JSON.stringify({ username }));
+      }
+
+      setNewUsername("");
+      setNewAge(0);
+      setProfileImage("");
+
+      alert("Profile saved");
+    } else {
+      alert("Failed to save profile");
+    }
   };
 
   return (


### PR DESCRIPTION
## Summary
- enable editing username, age, and profile image in the settings page
- update user state after a successful save

## Testing
- `npm run lint`
- `npm run build` *(fails: Route `app/api/comments/[id]/route.ts` has an invalid "POST" export)*

------
https://chatgpt.com/codex/tasks/task_e_685ba2d9e0a0832694c03404f45e7d55