### PR TITLE
Enable global theme switching

### DIFF
--- a/app/context/ThemeContext.tsx
+++ b/app/context/ThemeContext.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { createContext, useContext, useEffect, useState } from "react";
+
+export type Theme = "brightness" | "night";
+
+interface ThemeContextValue {
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue | undefined>(undefined);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setThemeState] = useState<Theme>("brightness");
+
+  // load theme from localStorage on mount
+  useEffect(() => {
+    const stored = localStorage.getItem("theme") as Theme | null;
+    if (stored === "night" || stored === "brightness") {
+      setThemeState(stored);
+    }
+  }, []);
+
+  // apply theme classes and persist changes
+  useEffect(() => {
+    localStorage.setItem("theme", theme);
+    if (theme === "night") {
+      document.body.classList.add("bg-dark", "text-white");
+      document.body.classList.remove("bg-gray-50");
+    } else {
+      document.body.classList.remove("bg-dark", "text-white");
+      document.body.classList.add("bg-gray-50");
+    }
+  }, [theme]);
+
+  const setTheme = (value: Theme) => {
+    setThemeState(value);
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) {
+    throw new Error("useTheme must be used within a ThemeProvider");
+  }
+  return ctx;
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,14 +2,17 @@
 import "./globals.css";
 // Context provider that manages authentication state
 import { AuthProvider } from "./context/AuthContext";
+import { ThemeProvider } from "./context/ThemeContext";
 
 // Root layout shared by all routes
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
       <body className="min-h-screen bg-gray-50">
-        {/* Provide authentication context to the entire app */}
-        <AuthProvider>{children}</AuthProvider>
+        {/* Provide authentication and theme context to the entire app */}
+        <AuthProvider>
+          <ThemeProvider>{children}</ThemeProvider>
+        </AuthProvider>
       </body>
     </html>
   );

--- a/app/setting/page.tsx
+++ b/app/setting/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../context/AuthContext";
+import { useTheme } from "../context/ThemeContext";
 import TopBar from "../components/TopBar";
 
 interface User {
@@ -22,7 +23,7 @@ export default function SettingPage() {
   const [newUsername, setNewUsername] = useState("");
   const [newAge, setNewAge] = useState<number>(0);
   const [profileImage, setProfileImage] = useState<string>("");
-  const [theme, setTheme] = useState<"brightness" | "night">("brightness");
+  const { theme, setTheme } = useTheme();
 
   // Convert selected image file to base64 string
   const handleImageUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -52,27 +53,8 @@ export default function SettingPage() {
       .finally(() => setIsFetching(false));
   }, [user]);
 
-  // Load and apply theme from localStorage
-  useEffect(() => {
-    const savedTheme = localStorage.getItem("theme");
-    if (savedTheme === "night") {
-      setTheme("night");
-      document.body.classList.add("bg-dark", "text-white");
-    } else {
-      setTheme("brightness");
-      document.body.classList.remove("bg-dark", "text-white");
-    }
-  }, []);
-
-  // Apply theme changes
   const handleThemeChange = (value: "brightness" | "night") => {
     setTheme(value);
-    localStorage.setItem("theme", value);
-    if (value === "night") {
-      document.body.classList.add("bg-dark", "text-white");
-    } else {
-      document.body.classList.remove("bg-dark", "text-white");
-    }
   };
 
   const currentUserData = users.find((u) => u.username === user?.username);


### PR DESCRIPTION
## Summary
- implement `ThemeContext` with dark and light mode handling
- apply theme context in `RootLayout`
- use context inside settings page

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685baafa5a8483268ebc39d8afdcd313