### PR TITLE
Add theme-aware backgrounds

### DIFF
--- a/app/analysis/page.tsx
+++ b/app/analysis/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../context/AuthContext";
+import { useTheme } from "../context/ThemeContext";
 import TopBar from "../components/TopBar";
 
 interface User {
@@ -14,6 +15,7 @@ interface User {
 
 export default function AnalysisPage() {
   const { user, loading } = useAuth();
+  const { theme } = useTheme();
   const router = useRouter();
   const [users, setUsers] = useState<User[]>([]);
   const [isFetching, setIsFetching] = useState(true);
@@ -44,7 +46,11 @@ export default function AnalysisPage() {
   }
 
   return (
-    <div className="container-fluid min-vh-100 bg-light p-4">
+    <div
+      className={`container-fluid min-vh-100 p-4 ${
+        theme === "night" ? "bg-dark text-white" : "bg-light"
+      }`}
+    >
       {/* Sticky Top Bar and Menu */}
       <TopBar
         title="Analysis"

--- a/app/friend/page.tsx
+++ b/app/friend/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../context/AuthContext";
+import { useTheme } from "../context/ThemeContext";
 import TopBar from "../components/TopBar";
 
 interface User {
@@ -15,6 +16,7 @@ interface User {
 
 export default function FriendPage() {
   const { user, loading } = useAuth();
+  const { theme } = useTheme();
   const router = useRouter();
   const [users, setUsers] = useState<User[]>([]);
   const [friends, setFriends] = useState<string[]>([]);
@@ -62,7 +64,11 @@ export default function FriendPage() {
   const friendUsers = users.filter((u) => friends.includes(u.username));
 
   return (
-    <div className="container-fluid min-vh-100 bg-light p-4">
+    <div
+      className={`container-fluid min-vh-100 p-4 ${
+        theme === "night" ? "bg-dark text-white" : "bg-light"
+      }`}
+    >
       {/* Sticky Top Bar and Menu */}
       <TopBar
         title="Friend"

--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../context/AuthContext";
+import { useTheme } from "../context/ThemeContext";
 import TopBar from "../components/TopBar";
 import BlogCard from "../components/BlogCard";
 
@@ -28,6 +29,7 @@ interface BlogPost {
 
 export default function HomePage() {
   const { user, loading } = useAuth();
+  const { theme } = useTheme();
   const router = useRouter();
 
   const [users, setUsers] = useState<User[]>([]);
@@ -75,7 +77,11 @@ export default function HomePage() {
 
 
   return (
-    <div className="container-fluid min-vh-100 bg-light p-4">
+    <div
+      className={`container-fluid min-vh-100 p-4 ${
+        theme === "night" ? "bg-dark text-white" : "bg-light"
+      }`}
+    >
       {/* Sticky Top Bar and Menu */}
       <TopBar
         title="Home"
@@ -85,7 +91,9 @@ export default function HomePage() {
 
       {/* Create Blog Button */}
       <div
-        className="text-end bg-white py-3 px-4 position-sticky top-0 z-2"
+        className={`text-end py-3 px-4 position-sticky top-0 z-2 ${
+          theme === "night" ? "bg-dark text-white" : "bg-white"
+        }`}
         style={{ borderBottom: "1px solid #dee2e6" }}
       >
         <button

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../context/AuthContext";
+import { useTheme } from "../context/ThemeContext";
 import TopBar from "../components/TopBar";
 import BlogCard from "../components/BlogCard";
 
@@ -27,6 +28,7 @@ interface BlogPost {
 
 export default function PostsPage() {
   const { user, loading } = useAuth();
+  const { theme } = useTheme();
   const router = useRouter();
 
   const [users, setUsers] = useState<User[]>([]);
@@ -76,7 +78,11 @@ export default function PostsPage() {
   }
 
   return (
-    <div className="container-fluid bg-light min-vh-100 py-4">
+    <div
+      className={`container-fluid min-vh-100 py-4 ${
+        theme === "night" ? "bg-dark text-white" : "bg-light"
+      }`}
+    >
       <TopBar
         title="Posts"
         active="posts"
@@ -88,7 +94,9 @@ export default function PostsPage() {
 
       {/* Create Blog Button */}
       <div
-        className="text-end bg-white py-3 px-4 position-sticky top-0 z-2"
+        className={`text-end py-3 px-4 position-sticky top-0 z-2 ${
+          theme === "night" ? "bg-dark text-white" : "bg-white"
+        }`}
         style={{ borderBottom: "1px solid #dee2e6" }}
       >
         <button

--- a/app/signin/page.tsx
+++ b/app/signin/page.tsx
@@ -3,12 +3,14 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../context/AuthContext";
+import { useTheme } from "../context/ThemeContext";
 
 export default function SigninPage() {
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
   const [error, setError] = useState("");
   const { signin } = useAuth();
+  const { theme } = useTheme();
   const router = useRouter();
 
   const handleSignin = async () => {
@@ -21,7 +23,11 @@ export default function SigninPage() {
   };
 
   return (
-    <div className="d-flex align-items-center justify-content-center min-vh-100 bg-light">
+    <div
+      className={`d-flex align-items-center justify-content-center min-vh-100 ${
+        theme === "night" ? "bg-dark text-white" : "bg-light"
+      }`}
+    >
       <div className="card shadow" style={{ maxWidth: "28rem", width: "100%" }}>
         <div className="card-body">
           <h2 className="card-title h3 text-center mb-4">Sign In</h2>

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useAuth } from "../context/AuthContext";
+import { useTheme } from "../context/ThemeContext";
 
 export default function SignupPage() {
   const [username, setUsername] = useState("");
@@ -12,6 +13,7 @@ export default function SignupPage() {
   const [image, setImage] = useState<File | null>(null);
   const [error, setError] = useState("");
   const { signup } = useAuth();
+  const { theme } = useTheme();
   const router = useRouter();
 
   const handleSignup = async () => {
@@ -54,7 +56,11 @@ export default function SignupPage() {
   };
 
   return (
-    <div className="d-flex align-items-center justify-content-center min-vh-100 bg-light">
+    <div
+      className={`d-flex align-items-center justify-content-center min-vh-100 ${
+        theme === "night" ? "bg-dark text-white" : "bg-light"
+      }`}
+    >
       <div className="card shadow" style={{ maxWidth: "28rem", width: "100%" }}>
         <div className="card-body">
           <h2 className="card-title h3 text-center mb-4">Sign Up</h2>

--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -4,10 +4,12 @@ import { useEffect, useState } from "react";
 import { useAuth } from "../context/AuthContext";
 import { useRouter } from "next/navigation";
 import "bootstrap-icons/font/bootstrap-icons.css";
+import { useTheme } from "../context/ThemeContext";
 import TopBar from "../components/TopBar";
 
 export default function UserPage() {
   const { user, loading } = useAuth();
+  const { theme } = useTheme();
   const router = useRouter();
 
   interface User {
@@ -131,7 +133,11 @@ export default function UserPage() {
     .filter((u) => u.username.toLowerCase().includes(searchTerm.toLowerCase()));
 
   return (
-    <div className="container-fluid min-vh-100 bg-light p-4">
+    <div
+      className={`container-fluid min-vh-100 p-4 ${
+        theme === "night" ? "bg-dark text-white" : "bg-light"
+      }`}
+    >
       {/* Sticky Top Bar and Menu */}
       <TopBar
         title="Home"


### PR DESCRIPTION
## Summary
- adjust page components to use `useTheme` for responsive backgrounds
- remove hard-coded light backgrounds in home and posts pages

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_685bad45df5c83268b37b114f86a78fc