### PR TITLE
Implement global dark/light theme

### DIFF
--- a/app/context/ThemeContext.tsx
+++ b/app/context/ThemeContext.tsx
@@ -25,7 +25,12 @@ export function ThemeProvider({ children }: { children: React.ReactNode }) {
   // apply theme classes and persist changes
   useEffect(() => {
     localStorage.setItem("theme", theme);
-    if (theme === "night") {
+    const isDark = theme === "night";
+    document.documentElement.setAttribute(
+      "data-bs-theme",
+      isDark ? "dark" : "light"
+    );
+    if (isDark) {
       document.body.classList.add("bg-dark", "text-white");
       document.body.classList.remove("bg-gray-50");
     } else {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -7,8 +7,8 @@ import { ThemeProvider } from "./context/ThemeContext";
 // Root layout shared by all routes
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="en">
-      <body className="min-h-screen bg-gray-50">
+    <html lang="en" data-bs-theme="light">
+      <body className="min-h-screen">
         {/* Provide authentication and theme context to the entire app */}
         <AuthProvider>
           <ThemeProvider>{children}</ThemeProvider>


### PR DESCRIPTION
## Summary
- inject Bootstrap data theme attribute when theme changes
- remove default body background so global theme applies

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bb811be308326b7f262d5c9cd8ea5