### PR TITLE
Fix file upload payload type

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -128,7 +128,7 @@ export default function ChatPage() {
     const reader = new FileReader();
     reader.onload = async () => {
       const isImage = file.type.startsWith("image/");
-      const payload: Message = {
+      const payload: Omit<Message, "_id"> = {
         from: user.username,
         to: chatUser,
         type: isImage ? "image" : "file",


### PR DESCRIPTION
## Summary
- fix type for file upload payload

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc --noEmit` *(fails: cannot find module 'mongoose', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_685ca57102e48326ac4876aae0eafe3a