### PR TITLE
Fix chat auto-scroll on page entry

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -80,12 +80,13 @@ export default function ChatPage() {
     return () => clearInterval(interval); // Cleanup
   }, [user, chatUser]);
 
-  // Scroll when a new message arrives from the chat partner
+  // Scroll when a new message arrives or when opening the chat
   useEffect(() => {
-    // Only scroll if the conversation grew and the last message is from the other user
+    // Only scroll if the conversation grew since last render
     if (messages.length > prevLengthRef.current) {
       const last = messages[messages.length - 1];
-      if (last && last.from === chatUser) {
+      // Scroll to the bottom on initial load or when the last message is from the chat partner
+      if (prevLengthRef.current === 0 || (last && last.from === chatUser)) {
         scrollToBottom();
       }
     }


### PR DESCRIPTION
## Summary
- when loading chat page, ensure view scrolls to the bottom so users always see the latest message

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685cad96fcf883268bcfb53b4e858aac