### PR TITLE
Hash passwords with bcrypt

### DIFF
--- a/app/api/auth/signin/route.ts
+++ b/app/api/auth/signin/route.ts
@@ -4,6 +4,8 @@ import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/mongodb';
 // Mongoose User model used to query the database
 import User from '@/models/User';
+// Library used to compare hashed passwords
+import bcrypt from 'bcrypt';
 
 // Handle POST /api/auth/signin to verify a user's credentials
 export async function POST(req: Request) {
@@ -13,10 +15,10 @@ export async function POST(req: Request) {
   // Ensure database connection is established
   await dbConnect();
 
-  // Look for a user document matching the credentials
-  const user = await User.findOne({ username, password });
+  // Look up the user by username
+  const user = await User.findOne({ username });
 
-  if (user) {
+  if (user && (await bcrypt.compare(password, user.password))) {
     // Credentials are valid; respond with the username
     return NextResponse.json({ success: true, username: user.username });
   }

--- a/app/api/auth/signup/route.ts
+++ b/app/api/auth/signup/route.ts
@@ -4,6 +4,8 @@ import { NextResponse } from 'next/server';
 import dbConnect from '@/lib/mongodb';
 // Mongoose model for persisting users
 import User from '@/models/User';
+// Library for hashing passwords
+import bcrypt from 'bcrypt';
 
 // Handle POST /api/auth/signup to create a new user account
 export async function POST(req: Request) {
@@ -14,8 +16,10 @@ export async function POST(req: Request) {
   await dbConnect();
 
   try {
+    // Hash the provided password before saving
+    const hashed = await bcrypt.hash(password, 10);
     // Insert the new user document with additional details
-    await User.create({ username, password, position, age, image });
+    await User.create({ username, password: hashed, position, age, image });
     return NextResponse.json({ success: true });
   } catch {
     // Likely a duplicate username or validation error

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "lucide-react": "^0.518.0",
         "mongodb": "^6.17.0",
         "mongoose": "^8.16.0",
+        "bcrypt": "^5.1.1",
         "next": "^15.3.4",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lucide-react": "^0.518.0",
     "mongodb": "^6.17.0",
     "mongoose": "^8.16.0",
+    "bcrypt": "^5.1.1",
     "next": "^15.3.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",


### PR DESCRIPTION
## Summary
- add bcrypt to project dependencies
- hash incoming passwords when signing up
- verify hashed passwords during sign in

## Testing
- `npm run lint` *(fails: `next: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e155507108326842e5ae0ab8c25fd