### PR TITLE
Add polling for user online status

### DIFF
--- a/app/user/page.tsx
+++ b/app/user/page.tsx
@@ -32,10 +32,18 @@ export default function UserPage() {
 
   useEffect(() => {
     if (!user) return;
-    fetch("/api/users")
-      .then((res) => res.json())
-      .then((data) => setUsers(data.users ?? []))
-      .catch(() => setUsers([]));
+    const fetchUsers = async () => {
+      try {
+        const res = await fetch("/api/users");
+        const data = await res.json();
+        setUsers(data.users ?? []);
+      } catch {
+        setUsers([]);
+      }
+    };
+    fetchUsers();
+    const interval = setInterval(fetchUsers, 5000);
+    return () => clearInterval(interval);
   }, [user]);
 
   if (loading || !user)


### PR DESCRIPTION
## Summary
- poll `/api/users` every 5 seconds in the user list page to keep online/offline status up to date

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e4f73e2a48326927fb1f7ebbdc42a