### PR TITLE
Add socket-based user status updates

### DIFF
--- a/app/friend/page.tsx
+++ b/app/friend/page.tsx
@@ -22,7 +22,7 @@ interface LastMessage {
 }
 
 export default function FriendPage() {
-  const { user, loading } = useAuth();
+  const { user, loading, socket } = useAuth();
   const { theme } = useTheme();
   const router = useRouter();
   const [users, setUsers] = useState<User[]>([]);
@@ -60,6 +60,28 @@ export default function FriendPage() {
 
     fetchData();
   }, [user]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const handleOnline = (username: string) => {
+      setUsers((prev) =>
+        prev.map((u) => (u.username === username ? { ...u, online: true } : u))
+      );
+    };
+    const handleOffline = (username: string) => {
+      setUsers((prev) =>
+        prev.map((u) =>
+          u.username === username ? { ...u, online: false } : u
+        )
+      );
+    };
+    socket.on("user-online", handleOnline);
+    socket.on("user-offline", handleOffline);
+    return () => {
+      socket.off("user-online", handleOnline);
+      socket.off("user-offline", handleOffline);
+    };
+  }, [socket]);
 
   useEffect(() => {
     const fetchLastMessages = async () => {

--- a/lib/socketServer.ts
+++ b/lib/socketServer.ts
@@ -1,0 +1,38 @@
+import { Server } from 'socket.io';
+import { createServer } from 'http';
+
+// Global type to avoid recreating the server on hot reloads
+interface GlobalWithIo extends NodeJS.Global {
+  _io?: Server;
+}
+
+const g = global as GlobalWithIo;
+
+// Initialize the Socket.IO server if it hasn't been created yet
+export function initSocketServer(port: number = Number(process.env.SOCKET_PORT) || 3001) {
+  if (!g._io) {
+    const httpServer = createServer();
+    g._io = new Server(httpServer, {
+      cors: { origin: '*' },
+    });
+    httpServer.listen(port, () => {
+      console.log(`Socket.IO server running on port ${port}`);
+    });
+  }
+  return g._io!;
+}
+
+export function emitUserOnline(username: string) {
+  const io = initSocketServer();
+  io.emit('user-online', username);
+}
+
+export function emitUserOffline(username: string) {
+  const io = initSocketServer();
+  io.emit('user-offline', username);
+}
+
+// Start the server automatically when executed directly
+if (require.main === module) {
+  initSocketServer();
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "next": "^15.3.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "socket.io-client": "^4.8.1"
+    "socket.io-client": "^4.8.1",
+    "socket.io": "^4.7.5"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",


### PR DESCRIPTION
## Summary
- implement a simple Socket.IO server
- emit online/offline events from user API
- manage a Socket.IO client in `AuthContext`
- update User, Friend and Chat pages to react to live status changes
- declare new server dependency

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f6c9181fc8326bd2edbd03aa5f760