### PR TITLE
Add socketRef for chat page

### DIFF
--- a/app/chat/page.tsx
+++ b/app/chat/page.tsx
@@ -25,6 +25,7 @@ export default function ChatPage() {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState("");
   const bottomRef = useRef<HTMLDivElement | null>(null);
+  const socketRef = useRef<Socket | null>(null);
   const prevLengthRef = useRef(0); // Initialize ref here
   const [selectedMsgId, setSelectedMsgId] = useState<string | null>(null);
   const [showScrollButton, setShowScrollButton] = useState(false);


### PR DESCRIPTION
## Summary
- keep a ref to the socket in `ChatPage`

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e4b96930832685e658ae9323e9a4