### PR TITLE
Handle tab visibility online updates

### DIFF
--- a/app/context/AuthContext.tsx
+++ b/app/context/AuthContext.tsx
@@ -84,6 +84,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     const handleVisibility = () => {
       if (document.visibilityState === "hidden") {
         markOffline();
+      } else if (document.visibilityState === "visible" && user) {
+        fetch(`/api/users/${user.username}`, {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: user.username,
+          },
+          body: JSON.stringify({ online: true }),
+        });
+        if (socket) socket.emit("user-online", user.username);
       }
     };
 


### PR DESCRIPTION
## Summary
- update `handleVisibility` in `AuthContext` to mark the user online when the tab becomes visible again

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860e6cf27dc8326b5304f1ebf6ebd18